### PR TITLE
Add scripts for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+dist: trusty
+
+language: c
+
+before_install:
+  - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get install -y --force-yes gcc-arm-none-eabi
+
+before_script:
+  - arm-none-eabi-gcc --version
+
+script:
+  - make && make test

--- a/Makefile
+++ b/Makefile
@@ -150,4 +150,7 @@ $(OBJDIR)/sensorweb.elf: $(OBJ)
 clean:
 	$(Q)$(RM) -rf $(OBJDIR)
 
+.PHONY: test
+test:
+
 -include $(OBJ:.o=.P)


### PR DESCRIPTION
The scripts in this patch enable the use of Travis CI on Github. There
are no tests yet, but automated builds should work.