### PR TITLE
Create producer-consumer tasks and IPC structures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ CXX = $(CROSS_COMPILE)g++
 OBJCOPY = $(CROSS_COMPILE)objcopy
 SIZE = $(CROSS_COMPILE)size
 
-DEFINES += -DUSE_FREERTOS=1
+DEFINES += -DUSE_FREERTOS=1 -Dgcc=1
 
 CPU := cortex-m4
 
@@ -49,10 +49,11 @@ SDK_PATH = external/cc3200-sdk
 DRIVERLIB = $(SDK_PATH)/driverlib
 OSLIB = $(SDK_PATH)/oslib
 FREERTOS = $(SDK_PATH)/third_party/FreeRTOS
+COMMON = $(SDK_PATH)/example/common
 
 CPPFLAGS += $(DEFINES) $(INC)
-CFLAGS += -ffunction-sections -fdata-sections
-CXXFLAGS += -ffunction-sections -fdata-sections
+CFLAGS += -ffunction-sections -fdata-sections -Wall -std=c11
+CXXFLAGS += -ffunction-sections -fdata-sections -Wall
 
 INC += -I$(SDK_PATH)
 INC += -I$(SDK_PATH)/inc
@@ -61,17 +62,29 @@ INC += -I$(DRIVERLIB)
 INC += -I$(FREERTOS)/source
 INC += -I$(FREERTOS)/source/include
 INC += -I$(FREERTOS)/source/portable/GCC/ARM_CM4
+INC += -I$(COMMON)
 
 LIBS =
 
 OBJDIR ?= obj
-OBJ := $(OBJDIR)/$(SDK_PATH)/example/common/startup_gcc.o
-OBJ += $(addprefix $(OBJDIR)/src/, \
+
+OBJ := $(addprefix $(OBJDIR)/src/, \
+	ApplicationHooks.o \
+	IPCQueue.o \
 	main.o \
+	pinmux.o \
+	Producer.o \
+	Serial.o \
+	Task.o \
 	)
 
 OBJ += $(addprefix $(OBJDIR)/$(OSLIB)/, \
 	osi_freertos.o \
+	)
+
+OBJ += $(addprefix $(OBJDIR)/$(COMMON)/, \
+	startup_gcc.o \
+	uart_if.o \
 	)
 
 OBJ += $(addprefix $(OBJDIR)/$(FREERTOS)/source/, \

--- a/src/ApplicationHooks.c
+++ b/src/ApplicationHooks.c
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+void
+vApplicationIdleHook(void)
+{
+}
+
+void
+vApplicationMallocFailedHook(void)
+{
+    while(1)
+    { }
+}
+
+void
+vApplicationStackOverflowHook(void)
+{
+    while(1)
+    { }
+}

--- a/src/IPCQueue.c
+++ b/src/IPCQueue.c
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "IPCQueue.h"
+
+/*
+ * IPCMessage
+ */
+
+int
+IPCMessageInit(IPCMessage* aMsg)
+{
+  aMsg->mDWord0 = 0;
+  aMsg->mDWord1 = 0;
+  aMsg->mStatus = 0;
+  aMsg->mBuffer = NULL;
+
+  return 0;
+}
+
+int
+IPCMessageProduce(IPCMessage* aMsg)
+{
+  /* TODO: At some point we have to implement efficient IPC with
+   * large buffers. IPCMessageProduce() will signal the end of the
+   * message constrcution **on the producer tast.** A produced
+   * message can be send over over an IPC queue to a consumer task.
+   * The consumer calls IPCMessageConsume() after it processed the
+   * buffer. The producer can then release the buffer. */
+  return 0;
+}
+
+int
+IPCMessageConsume(IPCMessage* aMsg)
+{
+  /* TODO: See IPCMessageProduce() */
+  return 0;
+}
+
+/*
+ * IPCMessageQueue
+ */
+
+int
+IPCMessageQueueInit(IPCMessageQueue* aMsgQueue)
+{
+  aMsgQueue->mWaitQueue = xQueueCreate(10, sizeof(IPCMessage));
+  if (!aMsgQueue->mWaitQueue) {
+    return -1;
+  }
+  return 0;
+}
+
+int
+IPCMessageQueueConsume(IPCMessageQueue* aMsgQueue, IPCMessage* aMsg)
+{
+	  BaseType_t res = xQueueSend(aMsgQueue->mWaitQueue, aMsg, 0);
+    if (res != pdPASS){
+      return -1;
+    }
+    return 0;
+}
+
+int
+IPCMessageQueueWait(IPCMessageQueue* aMsgQueue, IPCMessage* aMsg)
+{
+    BaseType_t res = xQueueReceive(aMsgQueue->mWaitQueue, aMsg, portMAX_DELAY);
+    if (res != pdPASS) {
+      return -1;
+    }
+    return 0;
+}

--- a/src/IPCQueue.h
+++ b/src/IPCQueue.h
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <FreeRTOS.h>
+#include <queue.h>
+
+#include <stdint.h>
+
+/*
+ * IPCMessage
+ */
+
+typedef struct
+{
+  /* Two dword for data transfers. */
+  uint32_t mDWord0;
+  uint32_t mDWord1;
+  /* Message flags [31:24] and buffer length [23:0] */
+  uint32_t mStatus;
+  /* Message buffer */
+  const void* mBuffer;
+} IPCMessage;
+
+int
+IPCMessageInit(IPCMessage* aMsg);
+
+int
+IPCMessageProduce(IPCMessage* aMsg);
+
+int
+IPCMessageConsume(IPCMessage* aMsg);
+
+/*
+ * IPCMessageQueue
+ */
+
+typedef struct
+{
+  QueueHandle_t mWaitQueue;
+
+  unsigned char mBuffer[1024];
+} IPCMessageQueue;
+
+int
+IPCMessageQueueInit(IPCMessageQueue* aMsgQueue);
+
+int
+IPCMessageQueueConsume(IPCMessageQueue* aMsgQueue,
+                       IPCMessage* aMsg);
+
+int
+IPCMessageQueueWait(IPCMessageQueue* aMsgQueue,
+                    IPCMessage* aMsg);

--- a/src/Producer.c
+++ b/src/Producer.c
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "Producer.h"
+
+#include <string.h>
+#include <uart_if.h>
+
+#include "IPCQueue.h"
+#include "Ptr.h"
+#include "Task.h"
+#include "Ticks.h"
+
+static void
+Run(ProducerTask* aProducer)
+{
+  static const char * const sMessage[] = {
+    "This"," is"," a"," SensorWeb"," device"," by"," Mozilla.\n\r"
+  };
+
+  for (unsigned long i = 0;; i = (i + 1) % ArrayLength(sMessage)) {
+    IPCMessage msg;
+    int res = IPCMessageInit(&msg);
+    if (res < 0) {
+      return;
+    }
+    msg.mBuffer = sMessage[i];
+    msg.mStatus = strlen(msg.mBuffer) + 1;
+
+    IPCMessageProduce(&msg);
+
+    res = IPCMessageQueueConsume(aProducer->mSendQueue, &msg);
+    if (res < 0) {
+      return;
+    }
+    vTaskDelay(TicksOfMSecs(200));
+  }
+}
+
+static void
+TaskEntryPoint(void* aParam)
+{
+  ProducerTask* producer = aParam;
+
+  Run(producer);
+
+  /* We mark ourselves for deletion. Deletion is done by
+   * the idle thread. We suspend until this happens. */
+  vTaskDelete(producer->mTask);
+  vTaskSuspend(producer->mTask);
+}
+
+int
+ProducerTaskInit(ProducerTask* aProducer, IPCMessageQueue* aSendQueue)
+{
+  aProducer->mSendQueue = aSendQueue;
+  aProducer->mTask = NULL;
+
+  return 0;
+}
+
+int
+ProducerTaskSpawn(ProducerTask* aProducer)
+{
+  BaseType_t res = xTaskCreate(TaskEntryPoint, "msg-producer",
+                               TaskDefaultStackSize(), aProducer,
+                               1, &aProducer->mTask);
+  if (res != pdPASS) {
+    return -1;
+  }
+  return 0;
+}
+

--- a/src/Producer.h
+++ b/src/Producer.h
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <FreeRTOS.h>
+#include <queue.h>
+#include <task.h>
+
+#include "IPCQueue.h"
+
+typedef struct
+{
+  IPCMessageQueue* mSendQueue;
+
+  TaskHandle_t mTask;
+} ProducerTask;
+
+int
+ProducerTaskInit(ProducerTask* aProducer, IPCMessageQueue* aSendQueue);
+
+int
+ProducerTaskSpawn(ProducerTask* aProducer);

--- a/src/Ptr.h
+++ b/src/Ptr.h
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#define ArrayLength(_array) \
+  ( sizeof(_array) / sizeof((_array[0])) )

--- a/src/Serial.c
+++ b/src/Serial.c
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "Serial.h"
+
+#include <uart_if.h>
+
+#include "Task.h"
+
+static void
+Run(SerialOutTask* aSerialOut)
+{
+  InitTerm();
+  ClearTerm();
+
+  for (;;) {
+    IPCMessage msg;
+    int res = IPCMessageQueueWait(&aSerialOut->mRecvQueue, &msg);
+    if (res < 0) {
+      return;
+    }
+    Report(msg.mBuffer);
+
+    IPCMessageConsume(&msg);
+  }
+}
+
+static void
+TaskEntryPoint(void* aParam)
+{
+  SerialOutTask* serialOut = aParam;
+
+  Run(serialOut);
+
+  /* We mark ourselves for deletion. Deletion is done by
+   * the idle thread. We suspend until this happens. */
+  vTaskDelete(serialOut->mTask);
+  vTaskSuspend(serialOut->mTask);
+}
+
+int
+SerialOutTaskInit(SerialOutTask* aSerialOut)
+{
+  int res = IPCMessageQueueInit(&aSerialOut->mRecvQueue);
+  if (res < 0) {
+    return res;
+  }
+  aSerialOut->mTask = NULL;
+
+  return 0;
+}
+
+int
+SerialOutTaskSpawn(SerialOutTask* aSerialOut)
+{
+  BaseType_t res = xTaskCreate(TaskEntryPoint, "serial-out",
+                               TaskDefaultStackSize(), aSerialOut,
+                               1, &aSerialOut->mTask);
+  if (res != pdPASS) {
+    return -1;
+  }
+  return 0;
+}

--- a/src/Serial.h
+++ b/src/Serial.h
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <FreeRTOS.h>
+#include <queue.h>
+#include <task.h>
+
+#include "IPCQueue.h"
+
+typedef struct
+{
+  IPCMessageQueue mRecvQueue;
+
+  TaskHandle_t mTask;
+} SerialOutTask;
+
+int
+SerialOutTaskInit(SerialOutTask* aSerialOut);
+
+int
+SerialOutTaskSpawn(SerialOutTask* aSerialOut);

--- a/src/Task.c
+++ b/src/Task.c
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "Task.h"
+
+#define WORD_SIZE sizeof(uint32_t)
+
+static inline size_t nwords_of_nbytes(size_t nbytes)
+{
+  return nbytes / WORD_SIZE + !!(nbytes % WORD_SIZE);
+}
+
+static inline uint16_t default_stack_size(void)
+{
+  return nwords_of_nbytes(2048);
+}
+
+uint16_t
+TaskDefaultStackSize()
+{
+  return default_stack_size();
+}

--- a/src/Task.h
+++ b/src/Task.h
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <FreeRTOS.h>
+#include <task.h>
+
+uint16_t
+TaskDefaultStackSize(void);

--- a/src/Ticks.h
+++ b/src/Ticks.h
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <FreeRTOS.h>
+
+static inline TickType_t TicksOfMSecs(uint32_t msecs)
+{
+  return msecs / portTICK_PERIOD_MS + !!(msecs % portTICK_PERIOD_MS);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -2,15 +2,68 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-void vApplicationStackOverflowHook()
-{
-    while(1)
-    {
-    }
-}
+#include <hw_ints.h>
+#include <hw_types.h>
+#include <interrupt.h>
+#include <prcm.h>
+#include <rom_map.h>
+#include <stdlib.h>
 
+#include "pinmux.h"
+#include "Producer.h"
+#include "Serial.h"
 
-int main(void)
+extern void (* const g_pfnVectors[])(void);
+
+int
+main(void)
 {
-	return 0;
+  /*
+   * Initialize board
+   */
+
+  // Set vector table base
+  MAP_IntVTableBaseSet((unsigned long)g_pfnVectors);
+
+  // Enable Processor
+  MAP_IntMasterEnable();
+  MAP_IntEnable(FAULT_SYSTICK);
+
+  PRCMCC3200MCUInit();
+
+  PinMuxConfig();
+
+  /*
+   * Create the output task
+   */
+
+  static SerialOutTask serialOutTask;
+
+  if (SerialOutTaskInit(&serialOutTask) < 0) {
+    return EXIT_FAILURE;
+  }
+  if (SerialOutTaskSpawn(&serialOutTask) < 0) {
+    return EXIT_FAILURE;
+  }
+
+  /*
+   * Create the producer task
+   */
+
+  static ProducerTask producerTask;
+
+  if (ProducerTaskInit(&producerTask, &serialOutTask.mRecvQueue) < 0) {
+    return EXIT_FAILURE;
+  }
+  if (ProducerTaskSpawn(&producerTask) < 0) {
+    return EXIT_FAILURE;
+  }
+
+  /*
+   * Start the task scheduler
+   */
+
+  vTaskStartScheduler();
+
+  return EXIT_SUCCESS;
 }

--- a/src/pinmux.c
+++ b/src/pinmux.c
@@ -1,0 +1,72 @@
+//*****************************************************************************
+// pinmux.c
+//
+// configure the device pins for different peripheral signals
+//
+// Copyright (C) 2014 Texas Instruments Incorporated - http://www.ti.com/ 
+// 
+// 
+//  Redistribution and use in source and binary forms, with or without 
+//  modification, are permitted provided that the following conditions 
+//  are met:
+//
+//    Redistributions of source code must retain the above copyright 
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the 
+//    documentation and/or other materials provided with the   
+//    distribution.
+//
+//    Neither the name of Texas Instruments Incorporated nor the names of
+//    its contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************
+
+// This file was automatically generated on 7/21/2014 at 3:06:20 PM
+// by TI PinMux version 3.0.334
+//
+//*****************************************************************************
+
+#include "pinmux.h"
+#include "hw_types.h"
+#include "hw_memmap.h"
+#include "hw_gpio.h"
+#include "pin.h"
+#include "rom.h"
+#include "rom_map.h"
+#include "gpio.h"
+#include "prcm.h"
+
+//*****************************************************************************
+void
+PinMuxConfig(void)
+{
+    //
+    // Enable Peripheral Clocks 
+    //
+    MAP_PRCMPeripheralClkEnable(PRCM_UARTA0, PRCM_RUN_MODE_CLK);
+
+    //
+    // Configure PIN_55 for UART0 UART0_TX
+    //
+    MAP_PinTypeUART(PIN_55, PIN_MODE_3);
+
+    //
+    // Configure PIN_57 for UART0 UART0_RX
+    //
+    MAP_PinTypeUART(PIN_57, PIN_MODE_3);
+}

--- a/src/pinmux.h
+++ b/src/pinmux.h
@@ -1,0 +1,57 @@
+//*****************************************************************************
+// pinmux.h
+//
+// function prototype for pinmuxconfig
+//
+// Copyright (C) 2014 Texas Instruments Incorporated - http://www.ti.com/ 
+// 
+// 
+//  Redistribution and use in source and binary forms, with or without 
+//  modification, are permitted provided that the following conditions 
+//  are met:
+//
+//    Redistributions of source code must retain the above copyright 
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the 
+//    documentation and/or other materials provided with the   
+//    distribution.
+//
+//    Neither the name of Texas Instruments Incorporated nor the names of
+//    its contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************
+
+// This file was automatically generated on 7/21/2014 at 3:06:20 PM
+// by TI PinMux version 3.0.334
+//
+//*****************************************************************************
+
+#ifndef __PINMUX_H__
+#define __PINMUX_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void PinMuxConfig(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif //  __PINMUX_H__


### PR DESCRIPTION
This patch adds the basic blocks for IPC. It adds a producer and a
consumer task. The producer creates IPC messages and forwards them
to the consumer.
